### PR TITLE
Now we can run pymodoro for only one line of output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,20 @@
 
 ## Running
 
-To run, put the files into a new folder called **.pymodoro** inside your home folder. Configure your xmobar to display pymodoro with
+### Xmobar
+
+Put the files into a new folder called **.pymodoro** inside your home folder. Configure your xmobar to display pymodoro with
 
     Run CommandReader "~/.pymodoro/pymodoro.py" "pomodoro"
 
 Then add it to your template.
+
+### Dzen2
+
+Add the following configuration to your Dzen2 configuration file to retrieve the current status of your Pomodoro and paste it in your display.
+
+    ^fg(\#FFFFFF)${execi 10 python ~/.pymodoro/pymodoro.py -o}
+
 
 ## Install
 
@@ -22,7 +31,7 @@ A new Pomodoro -- 25 minutes followed by a break of 5 minutes -- is started by c
 
 If you want to use counters with different times, write them into the session file. The first number specifies the length of the Pomodoro in minutes, the second one the length of the break. Both numbers are optional. Example:
 
-    echo "20 2" > pomodoro_session
+    echo "20 2" > ~/.pomodoro_session
 
 ### Keybindings
 

--- a/pymodoro.py
+++ b/pymodoro.py
@@ -57,6 +57,9 @@ class Config(object):
         self.break_sound_file = os.path.join(self.data_path, 'break.wav')
         self.tick_sound_file = os.path.join(self.data_path, 'tick.wav')
 
+        # Run until SIGINT or any other interrupts by default.
+        self.enable_only_one_line = False
+
     def load_user_data(self):
         """
         Custom User Data
@@ -102,6 +105,8 @@ class Config(object):
 
         self.session_file = self._config_get_quoted_string('General', 'session')
         self.auto_hide = self._parser.getboolean('General', 'autohide')
+        # Set 'oneline' to True if you want pymodoro to output only one line and exit.
+        self.enable_only_one_line = self._parser.getboolean('General', 'oneline')
 
         self.pomodoro_prefix = self._config_get_quoted_string('Labels', 'pomodoro_prefix')
         self.pomodoro_suffix = self._config_get_quoted_string('Labels', 'pomodoro_suffix')
@@ -117,10 +122,12 @@ class Config(object):
         self.enable_sound = self._parser.getboolean('Sound', 'enable')
         self.enable_tick_sound = self._parser.getboolean('Sound', 'tick')
 
+
     def _create_config_file(self):
         self._parser.add_section('General')
         self._parser.set('General', 'autohide', str(self.auto_hide).lower())
         self._config_set_quoted_string('General', 'session', self.session_file)
+        self._parser.set('General', 'oneline', str(self.enable_only_one_line).lower())
 
         self._parser.add_section('Labels')
         self._config_set_quoted_string('Labels', 'pomodoro_prefix', self.pomodoro_prefix)

--- a/pymodoro.py
+++ b/pymodoro.py
@@ -188,6 +188,8 @@ class Config(object):
         arg_parser.add_argument('-pp', '--pomodoro-prefix', action='store', help='String to display before, when we are in a pomodoro. Default to "P". Can be used to format display for dzen.', metavar='POMODORO PREFIX', dest='pomodoro_prefix')
         arg_parser.add_argument('-ps', '--pomodoro-suffix', action='store', help='String to display after, when we are in a pomodoro. Default to "". Can be used to format display for dzen.', metavar='POMODORO SUFFIX', dest='pomodoro_suffix')
 
+        arg_parser.add_argument('-o', '--one-line', action='store_true', help='Print one line of output and quit.', dest='oneline')
+
         args = arg_parser.parse_args()
 
         if args.session_duration:
@@ -237,6 +239,9 @@ class Config(object):
         if args.pomodoro_suffix:
             self.pomodoro_suffix = args.pomodoro_suffix
 
+        if args.oneline:
+            self.enable_only_one_line = True
+
 class Pymodoro(object):
 
     IDLE_STATE = 'IDLE'
@@ -256,7 +261,10 @@ class Pymodoro(object):
             self.update_state()
             self.print_output()
             self.tick_sound()
-            self.wait()
+            if self.config.enable_only_one_line:
+                break
+            else:
+                self.wait()
 
     def update_state(self):
         """ Update the current state determined by timings."""


### PR DESCRIPTION
I made this change to run pymodoro for getting only one result and exiting.

Add -o to just get one line and exit.

I needed this because AFAIK dzen2 does not support long-running processes.

I then added this to my conkyrc:

```
background yes
out_to_console yes
out_to_x no
# Update interval in seconds
update_interval 1

TEXT
^i(/home/onur/.xmonad/dzen2/xbm/cpu.xbm) ^fg(\#FFFFFF)${cpu}% ^i(/home/onur/.xmonad/dzen2/xbm/mem.xbm) ^fg(\#FFFFFF)${memperc}% ^fg(\#ebac54) ^fg(\#FFFFFF)${execi 10 python ~/.pymodoro/pymodoro.py -o}
```