### PR TITLE
adding call to os.path.expanduser() for session file (~/.pomodoro_sessio...

### DIFF
--- a/pymodoro.py
+++ b/pymodoro.py
@@ -29,7 +29,7 @@ class Config(object):
     def load_defaults(self):
         self.script_path = self._get_script_path()
         self.data_path = os.path.join(self.script_path, 'data')
-        self.session_file = '~/.pomodoro_session'
+        self.session_file = os.path.expanduser('~/.pomodoro_session')
         self.auto_hide = False
 
         # Times


### PR DESCRIPTION
Fixing some difficulty finding the session file for reading the desired durations by making a call to os.path.expanduser()