### PR TITLE
Fix python3 compatibility

### DIFF
--- a/pymodoro.py
+++ b/pymodoro.py
@@ -154,7 +154,7 @@ class Config(object):
         if not os.path.exists(self._dir):
             os.makedirs(self._dir)
 
-        with open(self._file, 'wb') as configfile:
+        with open(self._file, 'at') as configfile:
             self._parser.write(configfile)
 
     def _config_set_quoted_string(self, section, option, value):


### PR DESCRIPTION
As you now need to encode explicitly strings in python3, I'm using text mode for writing the config file as it does it automatically.

It allows compatibilty with python 2 and 3