### PR TITLE
Fix oneline state

### DIFF
--- a/pymodoro.py
+++ b/pymodoro.py
@@ -298,10 +298,16 @@ class Pymodoro(object):
         if not hasattr(self, 'state'):
             self.state = self.IDLE_STATE
 
-        current_state = self.state
         seconds_left = self.get_seconds_left()
+
+        if seconds_left is not None and seconds_left > 0:
+            self.state = self.ACTIVE_STATE
+
+        current_state = self.state
+
         break_duration = self.config.break_duration_in_seconds
         break_elapsed = self.get_break_elapsed(seconds_left)
+
 
         if seconds_left is None:
             next_state = self.IDLE_STATE
@@ -311,6 +317,9 @@ class Pymodoro(object):
             next_state = self.BREAK_STATE
         else:
             next_state = self.WAIT_STATE
+
+        print("current_state " + current_state)
+        print("next_state " + next_state)
 
         if next_state is not current_state:
             self.send_notifications(next_state)

--- a/pymodoro.py
+++ b/pymodoro.py
@@ -299,27 +299,28 @@ class Pymodoro(object):
             self.state = self.IDLE_STATE
 
         seconds_left = self.get_seconds_left()
-
-        if seconds_left is not None and seconds_left > 0:
-            self.state = self.ACTIVE_STATE
-
-        current_state = self.state
-
         break_duration = self.config.break_duration_in_seconds
         break_elapsed = self.get_break_elapsed(seconds_left)
 
+        if seconds_left is None:
+            self.state = self.IDLE_STATE
+        elif seconds_left >= 0:
+            self.state = self.ACTIVE_STATE
+        elif break_elapsed <= break_duration:
+            self.state = self.BREAK_STATE
+        else:
+            self.state = self.WAIT_STATE
+
+        current_state = self.state
 
         if seconds_left is None:
             next_state = self.IDLE_STATE
-        elif seconds_left > 0:
+        elif seconds_left > 1:
             next_state = self.ACTIVE_STATE
-        elif break_elapsed < break_duration:
+        elif break_elapsed + 1 < break_duration or seconds_left == 1:
             next_state = self.BREAK_STATE
         else:
             next_state = self.WAIT_STATE
-
-        print("current_state " + current_state)
-        print("next_state " + next_state)
 
         if next_state is not current_state:
             self.send_notifications(next_state)


### PR DESCRIPTION
Hi,

I encountered a problem with the oneline parameter (that I'm using for i3status compatibility).
When used with the oneline parameter, there is no "current_state" value as the program exits after each iteration, displaying only one line. So the state value was always IDLE_STATE (the default) and break/session notifications were not send.
Instead of relying on this state property value, I am now computing it based on the seconds_left / break values.
Regards,