### PR TITLE
Fix sound_command in config file creation

### DIFF
--- a/pymodoro.py
+++ b/pymodoro.py
@@ -162,7 +162,7 @@ class Config(object):
         self._parser.add_section('Sound')
         self._parser.set('Sound', 'enable', str(self.enable_sound).lower())
         self._parser.set('Sound', 'tick', str(self.enable_tick_sound).lower())
-        self._parser.set('Sound', 'command', str(self.sound_command).lower())
+        self._parser.set('Sound', 'sound_command', str(self.sound_command).lower())
 
         if not os.path.exists(self._dir):
             os.makedirs(self._dir)


### PR DESCRIPTION
The config file loader looks for a 'sound_command' setting, but the config file creator creates a 'command' setting instead, which is always ignored.